### PR TITLE
disable external use of /api/quotas

### DIFF
--- a/server/services/index.js
+++ b/server/services/index.js
@@ -174,5 +174,4 @@ module.exports = function () { // 'function' needed as we use 'this'
       });
     },
   });
-
 };

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -127,6 +127,12 @@ module.exports = function () { // 'function' needed as we use 'this'
     name: 'quotas',
   }));
 
+  app.service('/api/quotas').before({
+    // disable external use (rest / websocket ) of /api/quotas
+    all: hooks.disable('external'),
+  });
+
+
   const populateEventsSchema = {
     include: [{
       service: '/api/quotas',
@@ -168,4 +174,5 @@ module.exports = function () { // 'function' needed as we use 'this'
       });
     },
   });
+
 };


### PR DESCRIPTION
requests from rest and websockets are disabled for /api/quotas since this is only accessed by the backend