### PR TITLE
REST endpoints improved

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "extract-text-webpack-plugin": "^1.0.0",
     "feathers": "^2.0.3",
     "feathers-hooks": "^1.7.1",
+    "feathers-hooks-common": "^2.0.3",
     "feathers-knex": "^2.6.0",
     "feathers-rest": "^1.5.2",
     "file-loader": "^0.9.0",

--- a/scripts/create-fake-data.js
+++ b/scripts/create-fake-data.js
@@ -58,6 +58,7 @@ const quotas = [
   {
     eventId: 1,
     title: 'Minuuttikalja 2016',
+    // going fields doesn't exist in db, but it's used to create right amount of signups
     going: 18,
     size: 20,
     signupOpens: moment(now).subtract(50, 'days').format(d),
@@ -195,6 +196,10 @@ quotas.map((quota, quotaIndex) => {
   }
   return true;
 });
+
+for (let i = 0; i < quotas.length; i += 1) {
+  delete quotas[i].going;
+}
 
 db('events').insert(events)
   .then(() => db('quotas').insert(quotas))

--- a/scripts/reset-database.js
+++ b/scripts/reset-database.js
@@ -49,7 +49,6 @@ db.schema.dropTableIfExists('events')
       table.increments('id');
       table.integer('eventId');
       table.string('title');
-      table.integer('going');
       table.integer('size');
       table.dateTime('signupOpens');
       table.dateTime('signupCloses');

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -61,17 +61,8 @@ module.exports = function () { // eslint-disable-line
     all: hooks.disable('external'),
   });
 
-  // const populateEventsSchema = {
-  //   include: [{
-  //     service: '/api/quotas',
-  //     nameAs: 'quotas',
-  //     parentField: 'id',
-  //     childField: 'eventId',
-  //     asArray: true,
-  //   }],
-  // };
-
-  const schema = {
+  // Fields to fetch from db
+  const populateEvents = {
     include: [
       {
         service: '/api/quotas',
@@ -91,7 +82,8 @@ module.exports = function () { // eslint-disable-line
     ],
   };
 
-  const serializeSchema = {
+  // Clean output for REST endpoint
+  const serializeEvents = {
     only: ['id', 'title', 'date'],
     quotas: {
       only: ['title', 'size', 'signupOpens', 'signupCloses'],
@@ -102,6 +94,7 @@ module.exports = function () { // eslint-disable-line
     },
   };
 
+  // Fields to fetch from db
   const populateSingleEvent = {
     include: [{
       service: '/api/quotas',
@@ -132,21 +125,16 @@ module.exports = function () { // eslint-disable-line
     }],
   };
 
-  app.service('/api/events').before({
-    // GET /api/events
-    // find: [hooks.populate({ schema }), serialize(serializeSchema)],
-  });
-
-  // api/events hooks
   app.service('/api/events').after({
+    // GET /api/events
+    find: [hooks.populate({ schema: populateEvents }), hooks.serialize(serializeEvents)],
     // GET /api/events/<eventId>
     get: hooks.populate({ schema: populateSingleEvent }),
-    find: [hooks.populate({ schema }), hooks.serialize(serializeSchema)],
     create: (hook) => {
       // creates a new quota and attaches it to just created event
       app.service('/api/quotas').create({
         eventId: hook.result.id, // id of the just created event
-        title: 'Kiintiö tapahtumalle ',
+        title: 'Kiintiö tapahtumalle',
         size: 20,
         going: 10,
         signupOpens: '2017-1-1 23:59:59',

--- a/src/routes/Events/components/EventList.js
+++ b/src/routes/Events/components/EventList.js
@@ -9,15 +9,15 @@ import allTimesMatch from '../../../utils/allTimesMatch';
 
 class TableRow extends React.Component {
   render() {
-    const { title, link, date, signupLabel, going, size, className } = this.props;
+    const { title, link, date, signupLabel, signups, size, className } = this.props;
 
     return (
       <tr className={className}>
         <td key="title" className="title">{ link ? <Link to={link}>{title}</Link> : title }</td>
         <td key="date" className="date">{ date ? moment(date).format('DD.MM.YYYY') : '' }</td>
         <td key="signup" className="signup" data-xs-prefix={signupLabel ? 'Ilmoittautuminen ' : ''}>{signupLabel}</td>
-        <td key="going" className="going" data-xs-prefix={going || size ? 'Ilmoittautuneita: ' : ''}>
-          { going || '' }{ size ? <Separator /> : '' }{ size || ''}
+        <td key="signups" className="signups" data-xs-prefix={signups || size ? 'Ilmoittautuneita: ' : ''}>
+          { signups || 0 }{ size ? <Separator /> : '' }{ size || ''}
         </td>
       </tr>
     );
@@ -45,7 +45,7 @@ class EventList extends React.Component {
           link={`/event/${event.id}`}
           date={event.date}
           signupLabel={showOneLabel ? eventState.label : ''}
-          going={_.sumBy(event.quotas, 'going')}
+          signups={_.sumBy(event.quotas, 'signups')}
           size={_.sumBy(event.quotas, 'size')}
           className={eventState.class}
           key={`e${event.id}`} />,
@@ -58,7 +58,7 @@ class EventList extends React.Component {
             <TableRow
               title={quota.title}
               signupLabel={!showOneLabel ? quotaState.label : ''}
-              going={quota.going}
+              signups={quota.signups}
               size={quota.size}
               className={`${eventState.class} ${quotaState.class} child`}
               key={`q${i}`} />,
@@ -95,7 +95,7 @@ TableRow.propTypes = {
   link: React.PropTypes.string,
   signupLabel: React.PropTypes.string,
   className: React.PropTypes.string,
-  going: React.PropTypes.number,
+  signups: React.PropTypes.number,
   size: React.PropTypes.number,
 };
 

--- a/src/routes/SingleEvent/components/SignupList/SignupList.js
+++ b/src/routes/SingleEvent/components/SignupList/SignupList.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import _ from 'lodash';
 import './SignupList.scss';
 
 export class SignupList extends React.Component {
   render() {
-    const TableRow = ({ columns, attendee, index }) =>
+    const TableRow = ({ answers, attendee, index }) =>
       <tr>
         <td>{index}.</td>
         <td>{attendee}</td>
-        {columns.map((column, i) => <td key={i}>{column}</td>)}
+        {this.props.questions.map((q, i) => <td key={i}>{_.find(answers, { question: q.id }).answer}</td>)}
       </tr>;
-    // console.log(this.props.rows);
+
     return (
       <div>
         {this.props.title ? <h3>{this.props.title}</h3> : ''}
@@ -19,12 +20,12 @@ export class SignupList extends React.Component {
             <tr className='active'>
               <th key="position">Sija</th>
               <th key="attendee">Nimi</th>
-              {this.props.headings.map((h, i) => <th key={i}>{h}</th>)}
+              {this.props.questions.map((q, i) => <th key={i}>{q.question}</th>)}
             </tr>
           </thead>
           <tbody>
             {this.props.rows.map((row, i) =>
-              <TableRow columns={row.answers.map(a => a.answer)} attendee={row.attendee} index={i + 1} key={i} />)}
+              <TableRow answers={row.answers} attendee={row.attendee} index={i + 1} key={i} />)}
           </tbody>
         </table>
          }
@@ -35,7 +36,7 @@ export class SignupList extends React.Component {
 
 SignupList.propTypes = {
   title: React.PropTypes.string,
-  headings: React.PropTypes.array.isRequired,
+  questions: React.PropTypes.array.isRequired,
   rows: React.PropTypes.array.isRequired,
 };
 

--- a/src/routes/SingleEvent/components/SingleEvent.js
+++ b/src/routes/SingleEvent/components/SingleEvent.js
@@ -2,7 +2,6 @@ import React from 'react';
 import nl2br from 'react-nl2br';
 import _ from 'lodash';
 import moment from 'moment';
-import _ from 'lodash';
 import SignupButton from './SignupButton';
 import SignupList from './SignupList';
 import ViewProgress from './ViewProgress';

--- a/src/routes/SingleEvent/components/SingleEvent.js
+++ b/src/routes/SingleEvent/components/SingleEvent.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import nl2br from 'react-nl2br';
+import _ from 'lodash';
 import moment from 'moment';
 import SignupButton from './SignupButton';
 import SignupList from './SignupList';
@@ -79,7 +80,7 @@ class SingleEvent extends React.Component {
               <div className="sidebar-widget">
                 <h3>Ilmoittautuneet</h3>
                 {(event.quotas ? event.quotas.map((quota, index) =>
-                  <ViewProgress title={quota.title} value={quota.going} max={quota.size} key={index} />) : '')}
+                  <ViewProgress title={quota.title} value={quota.signups.length} max={quota.size} key={index} />) : '')}
               </div>
             </div>
             <div className="col-xs-12">
@@ -89,7 +90,7 @@ class SingleEvent extends React.Component {
                 {(event.quotas ? event.quotas.map((quota, index) =>
                   <SignupList
                     title={(event.quotas.length > 1 ? quota.title : '')}
-                    headings={event.questions.map(q => q.question)}
+                    questions={_.filter(event.questions, 'public')}
                     rows={quota.signups}
                     key={index}
                   />,


### PR DESCRIPTION
Endpointeista tuleva data siivottu (välitetään vain tarpeelliset kentät). Lisäksi going-kenttä poistettu tietokannasta ja korvattu kiintiön oikealla osallistujamäärällä (count). Vastauksista lähetetään API:n yli vain julkiset kentät, ja nekin on siivottu frontendille suoraan tarjoiltaviksi.

Endpointeille tulee vielä muokata permissionit (eli admineille lähetetään kaikki data), mutta se on helppo leipoa tuohon päälle feathersin permissioneilla.